### PR TITLE
Fix video overlay encoding to be cross-platform

### DIFF
--- a/work/scripts/build_2d_action_review.py
+++ b/work/scripts/build_2d_action_review.py
@@ -794,9 +794,17 @@ def build_video(video_path, raw_frames, records, events, out_dir, label, fps):
         raise RuntimeError(str(video_path))
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    temp = out_dir / f"{label}_2d_review.temp.mp4"
     out = out_dir / f"{label}_2d_review_overlay.mp4"
-    writer = cv2.VideoWriter(str(temp), cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height))
+    writer = subprocess.Popen(
+        [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "rawvideo", "-pix_fmt", "bgr24",
+            "-s", f"{width}x{height}", "-r", str(fps), "-i", "-",
+            "-an", "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+            "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(out),
+        ],
+        stdin=subprocess.PIPE,
+    )
     idx = 0
     while True:
         ok, frame = cap.read()
@@ -804,35 +812,12 @@ def build_video(video_path, raw_frames, records, events, out_dir, label, fps):
             break
         draw_skeleton(frame, records[idx], raw_frames[idx])
         draw_panel(frame, records[idx], None)
-        writer.write(frame)
+        writer.stdin.write(frame.tobytes())
         idx += 1
     cap.release()
-    writer.release()
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-i",
-            str(temp),
-            "-an",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-crf",
-            "20",
-            "-pix_fmt",
-            "yuv420p",
-            "-movflags",
-            "+faststart",
-            str(out),
-        ],
-        check=True,
-    )
-    temp.unlink(missing_ok=True)
+    writer.stdin.close()
+    if writer.wait() != 0:
+        raise RuntimeError(f"ffmpeg failed to encode {out}")
     return out
 
 

--- a/work/scripts/mediapipe_holistic_test.py
+++ b/work/scripts/mediapipe_holistic_test.py
@@ -157,9 +157,17 @@ def main():
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
     duration = frames_total / fps if fps else 0
 
-    temp_video = out_dir / f"{args.label}_holistic.temp.mp4"
     output_video = out_dir / f"{args.label}_holistic_overlay.mp4"
-    writer = cv2.VideoWriter(str(temp_video), cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height))
+    writer = subprocess.Popen(
+        [
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "rawvideo", "-pix_fmt", "bgr24",
+            "-s", f"{width}x{height}", "-r", str(fps), "-i", "-",
+            "-an", "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+            "-pix_fmt", "yuv420p", "-movflags", "+faststart", str(output_video),
+        ],
+        stdin=subprocess.PIPE,
+    )
 
     frame_records = []
     pose_count = left_hand_count = right_hand_count = 0
@@ -205,7 +213,7 @@ def main():
                 2,
                 cv2.LINE_AA,
             )
-            writer.write(frame)
+            writer.stdin.write(frame.tobytes())
 
             frame_records.append(
                 {
@@ -220,33 +228,10 @@ def main():
             frame_idx += 1
 
     cap.release()
-    writer.release()
+    writer.stdin.close()
+    if writer.wait() != 0:
+        raise RuntimeError(f"ffmpeg failed to encode {output_video}")
     elapsed = time.time() - started
-    subprocess.run(
-        [
-            "ffmpeg",
-            "-y",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-i",
-            str(temp_video),
-            "-an",
-            "-c:v",
-            "libx264",
-            "-preset",
-            "veryfast",
-            "-crf",
-            "20",
-            "-pix_fmt",
-            "yuv420p",
-            "-movflags",
-            "+faststart",
-            str(output_video),
-        ],
-        check=True,
-    )
-    temp_video.unlink(missing_ok=True)
 
     n = len(frame_records)
     metrics = {


### PR DESCRIPTION
cv2.VideoWriter with the mp4v fourcc fails to open on the macOS AVFoundation backend (FFMPEG: NO), so the temp .mp4 was never written and ffmpeg later failed with 'No such file or directory'. mp4v/avc1 availability differs per platform, so pipe raw frames straight to ffmpeg (libx264) instead, removing the temp file and the codec dependency. Fails loudly if ffmpeg errors.